### PR TITLE
Refactor command-line flags and remove obsolete tests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,7 +97,7 @@ func init() {
 
 	// Query flags
 	rootCmd.Flags().StringVarP(&profile, "profile", "p", "default", "config profile to use")
-	rootCmd.Flags().IntVar(&history, "history", 0, "number of commands from history to include")
+	rootCmd.Flags().IntVarP(&history, "history", "hs", 0, "number of commands from history to include")
 	rootCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "interactive mode with follow-ups")
 	rootCmd.Flags().BoolVarP(&explain, "explain", "e", false, "explain the command instead of just returning it")
 	rootCmd.Flags().StringVarP(&format, "format", "f", "plain", "output format: plain, json")

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -1,18 +1,19 @@
-package config
+package tests
 
 import (
+	"forgor/internal/config"
 	"testing"
 )
 
 func TestValidateProfile(t *testing.T) {
 	tests := []struct {
 		name    string
-		profile Profile
+		profile config.Profile
 		wantErr bool
 	}{
 		{
 			name: "valid openai profile",
-			profile: Profile{
+			profile: config.Profile{
 				Provider: "openai",
 				APIKey:   "test-key",
 				Model:    "gpt-4",
@@ -21,7 +22,7 @@ func TestValidateProfile(t *testing.T) {
 		},
 		{
 			name: "missing provider",
-			profile: Profile{
+			profile: config.Profile{
 				APIKey: "test-key",
 				Model:  "gpt-4",
 			},
@@ -29,7 +30,7 @@ func TestValidateProfile(t *testing.T) {
 		},
 		{
 			name: "missing model",
-			profile: Profile{
+			profile: config.Profile{
 				Provider: "openai",
 				APIKey:   "test-key",
 			},
@@ -37,7 +38,7 @@ func TestValidateProfile(t *testing.T) {
 		},
 		{
 			name: "missing api key for openai",
-			profile: Profile{
+			profile: config.Profile{
 				Provider: "openai",
 				Model:    "gpt-4",
 			},
@@ -45,7 +46,7 @@ func TestValidateProfile(t *testing.T) {
 		},
 		{
 			name: "valid local profile",
-			profile: Profile{
+			profile: config.Profile{
 				Provider: "local",
 				Model:    "llama2",
 				Endpoint: "http://localhost:8080",
@@ -54,7 +55,7 @@ func TestValidateProfile(t *testing.T) {
 		},
 		{
 			name: "missing endpoint for local",
-			profile: Profile{
+			profile: config.Profile{
 				Provider: "local",
 				Model:    "llama2",
 			},
@@ -62,7 +63,7 @@ func TestValidateProfile(t *testing.T) {
 		},
 		{
 			name: "unsupported provider",
-			profile: Profile{
+			profile: config.Profile{
 				Provider: "unsupported",
 				Model:    "test",
 				APIKey:   "test-key",
@@ -84,14 +85,14 @@ func TestValidateProfile(t *testing.T) {
 func TestConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		config  Config
+		cfg     config.Config
 		wantErr bool
 	}{
 		{
 			name: "valid config",
-			config: Config{
+			cfg: config.Config{
 				DefaultProfile: "test",
-				Profiles: map[string]Profile{
+				Profiles: map[string]config.Profile{
 					"test": {
 						Provider: "openai",
 						APIKey:   "test-key",
@@ -103,8 +104,8 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "missing default profile",
-			config: Config{
-				Profiles: map[string]Profile{
+			cfg: config.Config{
+				Profiles: map[string]config.Profile{
 					"test": {
 						Provider: "openai",
 						APIKey:   "test-key",
@@ -116,9 +117,9 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "default profile not found",
-			config: Config{
+			cfg: config.Config{
 				DefaultProfile: "missing",
-				Profiles: map[string]Profile{
+				Profiles: map[string]config.Profile{
 					"test": {
 						Provider: "openai",
 						APIKey:   "test-key",
@@ -130,9 +131,9 @@ func TestConfigValidate(t *testing.T) {
 		},
 		{
 			name: "invalid profile",
-			config: Config{
+			cfg: config.Config{
 				DefaultProfile: "test",
-				Profiles: map[string]Profile{
+				Profiles: map[string]config.Profile{
 					"test": {
 						Provider: "openai",
 						// Missing APIKey and Model
@@ -145,7 +146,7 @@ func TestConfigValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.Validate()
+			err := tt.cfg.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Config.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -154,9 +155,9 @@ func TestConfigValidate(t *testing.T) {
 }
 
 func TestGetProfile(t *testing.T) {
-	config := Config{
+	cfg := config.Config{
 		DefaultProfile: "default",
-		Profiles: map[string]Profile{
+		Profiles: map[string]config.Profile{
 			"default": {
 				Provider: "openai",
 				APIKey:   "default-key",
@@ -171,7 +172,7 @@ func TestGetProfile(t *testing.T) {
 	}
 
 	// Test getting default profile
-	profile, err := config.GetProfile("")
+	profile, err := cfg.GetProfile("")
 	if err != nil {
 		t.Errorf("GetProfile(\"\") returned error: %v", err)
 	}
@@ -180,7 +181,7 @@ func TestGetProfile(t *testing.T) {
 	}
 
 	// Test getting specific profile
-	profile, err = config.GetProfile("test")
+	profile, err = cfg.GetProfile("test")
 	if err != nil {
 		t.Errorf("GetProfile(\"test\") returned error: %v", err)
 	}
@@ -189,7 +190,7 @@ func TestGetProfile(t *testing.T) {
 	}
 
 	// Test getting non-existent profile
-	_, err = config.GetProfile("missing")
+	_, err = cfg.GetProfile("missing")
 	if err == nil {
 		t.Error("GetProfile(\"missing\") should have returned an error")
 	}

--- a/tests/pkg_version_test.go
+++ b/tests/pkg_version_test.go
@@ -1,16 +1,16 @@
-package pkg
+package tests
 
 import (
 	"testing"
 )
 
 // Version returns the current version for testing
-func Version() string {
+func pkgVersion() string {
 	return "test"
 }
 
-func TestVersion(t *testing.T) {
-	version := Version()
+func TestPkgVersion(t *testing.T) {
+	version := pkgVersion()
 	if version == "" {
 		t.Error("Version should not be empty")
 	}
@@ -20,8 +20,8 @@ func TestVersion(t *testing.T) {
 	}
 }
 
-func TestVersionFormat(t *testing.T) {
-	version := Version()
+func TestPkgVersionFormat(t *testing.T) {
+	version := pkgVersion()
 
 	// Test that version is a valid string
 	if len(version) == 0 {

--- a/tests/provider_test.go
+++ b/tests/provider_test.go
@@ -1,23 +1,24 @@
-package llm
+package tests
 
 import (
+	"forgor/internal/llm"
 	"testing"
 )
 
 func TestDangerLevel(t *testing.T) {
 	tests := []struct {
-		level DangerLevel
+		level llm.DangerLevel
 		value int
 	}{
-		{DangerLevelSafe, 0},
-		{DangerLevelLow, 1},
-		{DangerLevelMedium, 2},
-		{DangerLevelHigh, 3},
-		{DangerLevelCritical, 4},
+		{llm.DangerLevelSafe, 0},
+		{llm.DangerLevelLow, 1},
+		{llm.DangerLevelMedium, 2},
+		{llm.DangerLevelHigh, 3},
+		{llm.DangerLevelCritical, 4},
 	}
 
 	for _, test := range tests {
-		result := GetDangerLevelValue(test.level)
+		result := llm.GetDangerLevelValue(test.level)
 		if result != test.value {
 			t.Errorf("GetDangerLevelValue(%v) = %d; want %d", test.level, result, test.value)
 		}
@@ -26,26 +27,26 @@ func TestDangerLevel(t *testing.T) {
 
 func TestDangerLevelComparison(t *testing.T) {
 	// Test that danger levels have the expected relative values
-	if GetDangerLevelValue(DangerLevelSafe) >= GetDangerLevelValue(DangerLevelLow) {
+	if llm.GetDangerLevelValue(llm.DangerLevelSafe) >= llm.GetDangerLevelValue(llm.DangerLevelLow) {
 		t.Error("Safe should be less dangerous than Low")
 	}
 
-	if GetDangerLevelValue(DangerLevelLow) >= GetDangerLevelValue(DangerLevelMedium) {
+	if llm.GetDangerLevelValue(llm.DangerLevelLow) >= llm.GetDangerLevelValue(llm.DangerLevelMedium) {
 		t.Error("Low should be less dangerous than Medium")
 	}
 
-	if GetDangerLevelValue(DangerLevelMedium) >= GetDangerLevelValue(DangerLevelHigh) {
+	if llm.GetDangerLevelValue(llm.DangerLevelMedium) >= llm.GetDangerLevelValue(llm.DangerLevelHigh) {
 		t.Error("Medium should be less dangerous than High")
 	}
 
-	if GetDangerLevelValue(DangerLevelHigh) >= GetDangerLevelValue(DangerLevelCritical) {
+	if llm.GetDangerLevelValue(llm.DangerLevelHigh) >= llm.GetDangerLevelValue(llm.DangerLevelCritical) {
 		t.Error("High should be less dangerous than Critical")
 	}
 }
 
 func TestError(t *testing.T) {
-	err := &Error{
-		Type:    ErrorTypeNetwork,
+	err := &llm.Error{
+		Type:    llm.ErrorTypeNetwork,
 		Message: "test error",
 	}
 
@@ -56,9 +57,9 @@ func TestError(t *testing.T) {
 }
 
 func TestErrorWithCause(t *testing.T) {
-	causeErr := &testError{msg: "underlying error"}
-	err := &Error{
-		Type:    ErrorTypeNetwork,
+	causeErr := &providerTestError{msg: "underlying error"}
+	err := &llm.Error{
+		Type:    llm.ErrorTypeNetwork,
 		Message: "test error",
 		Cause:   causeErr,
 	}
@@ -70,7 +71,7 @@ func TestErrorWithCause(t *testing.T) {
 }
 
 func TestUsage(t *testing.T) {
-	usage := &Usage{
+	usage := &llm.Usage{
 		PromptTokens:     100,
 		CompletionTokens: 50,
 		TotalTokens:      150,
@@ -82,13 +83,13 @@ func TestUsage(t *testing.T) {
 }
 
 func TestResponse(t *testing.T) {
-	response := &Response{
+	response := &llm.Response{
 		Command:     "ls -la",
 		Explanation: "List files with details",
 		Confidence:  0.95,
-		DangerLevel: DangerLevelSafe,
+		DangerLevel: llm.DangerLevelSafe,
 		Warnings:    []string{},
-		Usage: &Usage{
+		Usage: &llm.Usage{
 			PromptTokens:     100,
 			CompletionTokens: 50,
 			TotalTokens:      150,
@@ -103,16 +104,16 @@ func TestResponse(t *testing.T) {
 		t.Errorf("Response Confidence should be between 0 and 1, got %f", response.Confidence)
 	}
 
-	if response.DangerLevel != DangerLevelSafe {
+	if response.DangerLevel != llm.DangerLevelSafe {
 		t.Errorf("Expected DangerLevelSafe, got %v", response.DangerLevel)
 	}
 }
 
 // Helper type for testing errors
-type testError struct {
+type providerTestError struct {
 	msg string
 }
 
-func (e *testError) Error() string {
+func (e *providerTestError) Error() string {
 	return e.msg
 }


### PR DESCRIPTION
- Changed the history flag in root command to use a shorthand option.
- Deleted outdated test files for config and LLM providers, as they are no longer needed.
